### PR TITLE
Fix a compile error on AMD / ROCM 3.5.0 with hip-clang

### DIFF
--- a/include/hipper/hipper_runtime.h
+++ b/include/hipper/hipper_runtime.h
@@ -267,7 +267,7 @@ inline bool operator!=(funcCache_t a, funcCache b)
 #if defined(HIPPER_CUDA)
 typedef cudaLimit limit_t;
 #elif defined(HIPPER_HIP)
-typedef hipLimit_t limit;
+typedef hipLimit_t limit_t;
 #endif
 enum limit
     {


### PR DESCRIPTION
A one-line fix to make `neighbor` compile