### PR TITLE
Add thin wrapper around CUB libraries

### DIFF
--- a/include/hipper/hipper_cub.h
+++ b/include/hipper/hipper_cub.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2020, Michael P. Howard. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef HIPPER_HIPPER_CUB_H_
+#define HIPPER_HIPPER_CUB_H_
+
+#include "hipper_runtime.h"
+
+#if defined(HIPPER_CUDA)
+#include <cub/cub.cuh>
+#elif defined(HIPPER_HIP)
+#include <hipcub/hipcub.hpp>
+#endif
+
+// alias the appropriate version of cub
+namespace hipper
+{
+#if defined(HIPPER_CUDA)
+namespace cub = ::cub;
+#elif defined(HIPPER_HIP)
+namespace cub = ::hipcub;
+#endif
+}
+
+#endif // HIPPER_HIPPER_CUB_H_

--- a/include/hipper/hipper_runtime.h
+++ b/include/hipper/hipper_runtime.h
@@ -899,19 +899,19 @@ __device__ inline dim3 gridSize()
 template<char GridDim=1, char BlockDim=1>
 __device__ int threadRank() = delete;
 template<>
-__device__ int threadRank<1,1>()
+inline __device__ int threadRank<1,1>()
     {
     return blockIndex().x*blockSize().x + threadIndex().x;
     }
 template<>
-__device__ int threadRank<1,2>()
+inline __device__ int threadRank<1,2>()
     {
     const dim3 bDim = blockSize();
     const dim3 tIdx = threadIndex();
     return blockIndex().x*bDim.x*(bDim.y + tIdx.y) + tIdx.x;
     }
 template<>
-__device__ int threadRank<1,3>()
+inline __device__ int threadRank<1,3>()
     {
     const dim3 bDim = blockSize();
     const dim3 tIdx = threadIndex();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,10 +2,12 @@
 set(HIPPER_TEST_FILES
     test_hipper.cc
     test_kernel.cu
+    test_cub.cu
 )
 # the list of test labels to turn into executables
 set(HIPPER_TEST_LABELS
     kernel
+    CUB
 )
 
 # look for catch quietly, and pull down v2.12.2 if not found

--- a/tests/test_cub.cu
+++ b/tests/test_cub.cu
@@ -1,0 +1,38 @@
+#include <hipper/hipper_runtime.h>
+#include <hipper/hipper_cub.h>
+#include "test_hipper.h"
+
+TEST_CASE("CUB operations", "[CUB]")
+    {
+    // input (array of integers)
+    int* a;
+    const int N = 2;
+    REQUIRE_SUCCESS(hipper::mallocManaged(reinterpret_cast<void**>(&a), sizeof(int)*N));
+    a[0] = 1;
+    a[1] = 2;
+
+    // output (sum of a)
+    int* total;
+    REQUIRE_SUCCESS(hipper::mallocManaged(reinterpret_cast<void**>(&total), sizeof(int)));
+    *total = 0;
+
+    // size temporary memory
+    void *tmp = NULL;
+    size_t tmp_bytes = 0;
+    hipper::cub::DeviceReduce::Sum(tmp,tmp_bytes,a,total,N);
+    REQUIRE_SUCCESS(hipper::mallocManaged(reinterpret_cast<void**>(&tmp), tmp_bytes));
+
+    // take sum
+    hipper::cub::DeviceReduce::Sum(tmp,tmp_bytes,a,total,N);
+    REQUIRE_SUCCESS(hipper::deviceSynchronize());
+
+    // check output
+    REQUIRE(a[0] == 1);
+    REQUIRE(a[1] == 2);
+    REQUIRE(*total == 3);
+
+    // free memory
+    REQUIRE_SUCCESS(hipper::free(a));
+    REQUIRE_SUCCESS(hipper::free(total));
+    REQUIRE_SUCCESS(hipper::free(tmp));
+    }


### PR DESCRIPTION
Implements #10 with a simple test.

Also fixes a linker error for template specializations in `hipper_runtime.h`, which I found when linking tests together.

Testing now implicitly requires CUB to be on your path (e.g., CUDA 11).