### PR TITLE
Removed deprecated APIs in CUDA 12.

### DIFF
--- a/include/hipper/hipper_runtime.h
+++ b/include/hipper/hipper_runtime.h
@@ -383,12 +383,6 @@ inline error_t deviceGetPCIBusId(char* pciBusId, int len, int device)
     return HIPPER(DeviceGetPCIBusId)(pciBusId, len, device);
     }
 
-//! Returns the shared memory configuration for the current device.
-inline error_t deviceGetSharedMemConfig(sharedMemConfig_t* config)
-    {
-    return HIPPER(DeviceGetSharedMemConfig)(config);
-    }
-
 //! Returns numerical values that correspond to the least and greatest stream priorities.
 inline error_t deviceGetStreamPriorityRange(int* leastPriority, int* greatestPriority)
     {
@@ -414,12 +408,6 @@ inline error_t deviceSetLimit(limit lim, size_t value)
     return HIPPER(DeviceSetLimit)(castLimit(lim), value);
     }
 #endif
-
-//! Sets the shared memory configuration for the current device.
-inline error_t deviceSetSharedMemConfig(sharedMemConfig config)
-    {
-    return HIPPER(DeviceSetSharedMemConfig)(castSharedMemConfig(config));
-    }
 
 //! Wait for compute device to finish.
 inline error_t deviceSynchronize(void)


### PR DESCRIPTION
Prevent these warnings when building HOOMD-blue:

```
/home/joaander/devel/hoomd-blue/hoomd/extern/hipper/include/hipper/hipper_runtime.h: In function ‘hipper::error_t hipper::deviceGetSharedMemConfig(hipper::sharedMemConfig_t*)’:
/home/joaander/devel/hoomd-blue/hoomd/extern/hipper/include/hipper/hipper_runtime.h:386:36: warning: ‘cudaError_t cudaDeviceGetSharedMemConfig(cudaSharedMemConfig*)’ is deprecated [-Wdeprecated-declarations]
  386 |     return HIPPER(DeviceGetSharedMemConfig)(config);
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/usr/local/cuda/targets/x86_64-linux/include/cuda_runtime_api.h:1059:46: note: declared here
 1059 | extern __CUDA_DEPRECATED __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaDeviceGetSharedMemConfig(enum cudaSharedMemConfig *pConfig);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joaander/devel/hoomd-blue/hoomd/extern/hipper/include/hipper/hipper_runtime.h: In function ‘hipper::error_t hipper::deviceSetSharedMemConfig(hipper::sharedMemConfig)’:
/home/joaander/devel/hoomd-blue/hoomd/extern/hipper/include/hipper/hipper_runtime.h:418:36: warning: ‘cudaError_t cudaDeviceSetSharedMemConfig(cudaSharedMemConfig)’ is deprecated [-Wdeprecated-declarations]
  418 |     return HIPPER(DeviceSetSharedMemConfig)(castSharedMemConfig(config));
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/cuda/targets/x86_64-linux/include/cuda_runtime_api.h:1105:46: note: declared here
 1105 | extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaDeviceSetSharedMemConfig(enum cudaSharedMemConfig config);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```